### PR TITLE
Add Version to RootCmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,8 +29,9 @@ func init() {
 }
 
 var RootCmd = &cobra.Command{
-	Use:   "apexfmt [file...]",
-	Short: "Format Apex",
+	Use:     "apexfmt [file...]",
+	Short:   "Format Apex",
+	Version: version,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if soql, _ := cmd.Flags().GetBool("soql"); soql {
 			formatSOQL()


### PR DESCRIPTION
Set the Cobra command's Version field (Version: version) on RootCmd so the CLI can report its version (e.g., via --version). Also adjust field alignment/spacing in the command struct.