### PR TITLE
Keep Closing Paren Of Wrapped Parameter Lists On Last Parameter Line

### DIFF
--- a/formatter/format_test.go
+++ b/formatter/format_test.go
@@ -964,8 +964,40 @@ public class SampleTest {}`,
 	public static void getInquiryMarketingOwners(
 		Set<Id> inqIds,/**first**/
 		Map<Id, Set<Id>> mapInqIdMarketingOwnerIds, /**second**/
-		Set<Id> inquiryMarketingOwnerIds /**third**/
-	) {}
+		Set<Id> inquiryMarketingOwnerIds /**third**/) {}
+}`,
+			},
+			{
+				`public class TestClass {
+	public void execute(Database.BatchableContext bc, Transaction__c[] scope, Map<Id, Set<Id>> ownersByInquiry) {
+		Integer i = 0;
+	}
+}`,
+				`public class TestClass {
+	public void execute(
+		Database.BatchableContext bc,
+		Transaction__c[] scope,
+		Map<Id, Set<Id>> ownersByInquiry) {
+		Integer i = 0;
+	}
+}`,
+			},
+			{
+				`public class TestClass {
+	public void execute(Database.BatchableContext bc,
+		Transaction__c[] scope, Map<Id, Set<Id>> ownersByInquiry // trailing comment
+	) {
+		Integer i = 0;
+	}
+}`,
+				`public class TestClass {
+	public void execute(
+		Database.BatchableContext bc,
+		Transaction__c[] scope,
+		Map<Id, Set<Id>> ownersByInquiry // trailing comment
+	) {
+		Integer i = 0;
+	}
 }`,
 			},
 			{

--- a/formatter/visitors.go
+++ b/formatter/visitors.go
@@ -1567,7 +1567,7 @@ func (v *FormatVisitor) VisitFormalParameters(ctx *parser.FormalParametersContex
 		}
 	}
 	if wrap {
-		return fmt.Sprintf("(\n%s\n)", strings.Join(params, ",\n"))
+		return fmt.Sprintf("(\n%s)", strings.Join(params, ",\n"))
 	} else {
 		return fmt.Sprintf("(%s)", strings.Join(params, ", "))
 	}


### PR DESCRIPTION
When a method declaration's parameters wrap to multiple lines, put the
closing paren and opening brace on the last parameter line instead of on
their own line, matching how wrapped if conditions are formatted.

A trailing line comment on the last parameter still forces the closing
paren onto its own line so it isn't swallowed by the comment.
